### PR TITLE
feat(telegram): Add a Telegram customer support channel

### DIFF
--- a/repos/tgo-api/app/schemas/chat.py
+++ b/repos/tgo-api/app/schemas/chat.py
@@ -62,6 +62,11 @@ class ChatCompletionRequest(BaseSchema):
         description="额外数据，会随消息一起转发到 WuKongIM",
         examples=[{"source": "web", "page": "/product/123"}]
     )
+    msg_type: Optional[int] = Field(
+        1,
+        description="消息类型：1-文本，2-图片，3-文件，4-语音，5-视频",
+        examples=[1, 2]
+    )
     forward_user_message_to_wukongim: bool = Field(
         default=True,
         description="是否将用户消息同时转发一份到 WuKongIM（默认开启）",

--- a/repos/tgo-api/app/services/platform_type_seed.py
+++ b/repos/tgo-api/app/services/platform_type_seed.py
@@ -76,7 +76,7 @@ SEED_PLATFORM_TYPES: List[Dict[str, object]] = [
         "type": "telegram",
         "name": "Telegram",
         "name_en": "Telegram",
-        "is_supported": False,
+        "is_supported": True,
     },
     {
         "type": "sms",

--- a/repos/tgo-platform/app/api/telegram_utils.py
+++ b/repos/tgo-platform/app/api/telegram_utils.py
@@ -1,0 +1,436 @@
+"""Telegram Bot API utilities.
+
+This module provides helper functions for interacting with the Telegram Bot API:
+- Sending text messages
+- Verifying webhook requests (optional secret_token)
+- Getting bot information
+
+Docs: https://core.telegram.org/bots/api
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Telegram Bot API base URL
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+async def telegram_send_text(
+    bot_token: str,
+    chat_id: str,
+    text: str,
+    parse_mode: str | None = None,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Send a text message via Telegram Bot API.
+
+    Args:
+        bot_token: Bot token from @BotFather
+        chat_id: Target chat ID (user, group, or channel)
+        text: Message text (max 4096 characters)
+        parse_mode: Optional parsing mode (Markdown, MarkdownV2, HTML)
+        timeout: Request timeout in seconds
+
+    Returns:
+        Telegram API response as dict
+
+    Raises:
+        httpx.HTTPStatusError: If the request fails
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage"
+    
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "text": text[:4096],  # Telegram text limit
+    }
+    
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        
+        if not result.get("ok"):
+            logger.error(
+                "[TELEGRAM] sendMessage failed: %s",
+                result.get("description", "Unknown error")
+            )
+        
+        return result
+
+
+async def telegram_send_photo(
+    bot_token: str,
+    chat_id: str,
+    photo: str | bytes,
+    caption: str | None = None,
+    parse_mode: str | None = None,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Send a photo via Telegram Bot API.
+
+    Args:
+        bot_token: Bot token from @BotFather
+        chat_id: Target chat ID
+        photo: Photo to send (URL as string, or raw bytes)
+        caption: Optional photo caption
+        parse_mode: Optional parsing mode for caption
+        timeout: Request timeout in seconds
+
+    Returns:
+        Telegram API response as dict
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/sendPhoto"
+    
+    data: dict[str, Any] = {
+        "chat_id": chat_id,
+    }
+    if caption:
+        data["caption"] = caption[:1024]
+    if parse_mode:
+        data["parse_mode"] = parse_mode
+
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        if isinstance(photo, bytes):
+            # Send as file (multipart)
+            files = {"photo": ("image.jpg", photo, "image/jpeg")}
+            response = await client.post(url, data=data, files=files)
+        else:
+            # Send as URL (string)
+            data["photo"] = photo
+            response = await client.post(url, data=data)
+            
+        response.raise_for_status()
+        result = response.json()
+        
+        if not result.get("ok"):
+            logger.error(
+                "[TELEGRAM] sendPhoto failed: %s",
+                result.get("description", "Unknown error")
+            )
+        
+        return result
+
+
+async def telegram_get_file(
+    bot_token: str,
+    file_id: str,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Get file information from Telegram.
+
+    Args:
+        bot_token: Bot token
+        file_id: File ID to get info for
+        timeout: Request timeout
+
+    Returns:
+        Telegram File object (includes file_path)
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/getFile"
+    payload = {"file_id": file_id}
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        return result
+
+
+async def telegram_download_file(
+    bot_token: str,
+    file_path: str,
+    timeout: int | None = None,
+) -> bytes:
+    """Download a file from Telegram.
+
+    Args:
+        bot_token: Bot token
+        file_path: File path obtained from getFile
+        timeout: Request timeout
+
+    Returns:
+        File content as bytes
+    """
+    url = f"{TELEGRAM_API_BASE}/file/bot{bot_token}/{file_path}"
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.content
+
+
+async def telegram_get_me(
+    bot_token: str,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Get information about the bot.
+
+    Args:
+        bot_token: Bot token from @BotFather
+        timeout: Request timeout in seconds
+
+    Returns:
+        Bot information as dict (id, is_bot, first_name, username, etc.)
+
+    Raises:
+        httpx.HTTPStatusError: If the request fails
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/getMe"
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+async def telegram_set_webhook(
+    bot_token: str,
+    webhook_url: str,
+    secret_token: str | None = None,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Set the webhook URL for the bot.
+
+    This configures Telegram to send updates to the specified URL.
+    Should be called when platform is enabled or bot_token is updated.
+
+    Args:
+        bot_token: Bot token from @BotFather
+        webhook_url: HTTPS URL for receiving updates
+        secret_token: Optional secret token for webhook verification
+        timeout: Request timeout in seconds
+
+    Returns:
+        Telegram API response
+
+    Raises:
+        httpx.HTTPStatusError: If the request fails
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/setWebhook"
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    payload: dict[str, Any] = {
+        "url": webhook_url,
+    }
+    
+    if secret_token:
+        payload["secret_token"] = secret_token
+
+    logger.info("[TELEGRAM] Setting webhook: %s", webhook_url)
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        
+        if result.get("ok"):
+            logger.info("[TELEGRAM] Webhook set successfully")
+        else:
+            logger.error(
+                "[TELEGRAM] Failed to set webhook: %s",
+                result.get("description", "Unknown error")
+            )
+        
+        return result
+
+
+async def telegram_delete_webhook(
+    bot_token: str,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    """Delete the webhook (disable webhook mode).
+
+    Should be called when platform is disabled.
+
+    Args:
+        bot_token: Bot token from @BotFather
+        timeout: Request timeout in seconds
+
+    Returns:
+        Telegram API response
+    """
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/deleteWebhook"
+    timeout_seconds = timeout or settings.request_timeout_seconds
+
+    logger.info("[TELEGRAM] Deleting webhook")
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        response = await client.post(url)
+        response.raise_for_status()
+        return response.json()
+
+
+def telegram_verify_secret_token(
+    request_secret_token: str,
+    expected_secret_token: str,
+) -> bool:
+    """Verify the X-Telegram-Bot-Api-Secret-Token header.
+
+    When setting up a webhook, you can provide a secret_token parameter.
+    Telegram will include this token in the X-Telegram-Bot-Api-Secret-Token
+    header of every webhook request.
+
+    Args:
+        request_secret_token: Token from request header
+        expected_secret_token: Expected token from platform config
+
+    Returns:
+        True if tokens match, False otherwise
+    """
+    if not expected_secret_token:
+        # No secret configured, skip verification
+        return True
+    
+    return hmac.compare_digest(request_secret_token or "", expected_secret_token)
+
+
+def extract_message_from_update(update: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract message data from a Telegram Update object.
+
+    Telegram sends different types of updates. This function extracts
+    the message from various update types.
+
+    Args:
+        update: Telegram Update object
+
+    Returns:
+        Message dict or None if no message found
+    """
+    # Check for regular message
+    if "message" in update:
+        return update["message"]
+    
+    # Check for edited message
+    if "edited_message" in update:
+        return update["edited_message"]
+    
+    # Check for channel post
+    if "channel_post" in update:
+        return update["channel_post"]
+    
+    # Check for edited channel post
+    if "edited_channel_post" in update:
+        return update["edited_channel_post"]
+    
+    # Check for callback query (button click)
+    if "callback_query" in update:
+        callback = update["callback_query"]
+        if "message" in callback:
+            return callback["message"]
+    
+    return None
+
+
+def extract_text_from_message(message: dict[str, Any]) -> str:
+    """Extract text content from a Telegram message.
+
+    Args:
+        message: Telegram Message object
+
+    Returns:
+        Text content or description of non-text content
+    """
+    # Regular text message
+    if "text" in message:
+        return message["text"]
+    
+    # Caption for media messages
+    if "caption" in message:
+        return message["caption"]
+    
+    # Photo
+    if "photo" in message:
+        return "[photo]"
+    
+    # Document
+    if "document" in message:
+        doc = message["document"]
+        return f"[document] {doc.get('file_name', '')}"
+    
+    # Voice message
+    if "voice" in message:
+        return "[voice message]"
+    
+    # Video
+    if "video" in message:
+        return "[video]"
+    
+    # Audio
+    if "audio" in message:
+        audio = message["audio"]
+        return f"[audio] {audio.get('title', audio.get('file_name', ''))}"
+    
+    # Sticker
+    if "sticker" in message:
+        sticker = message["sticker"]
+        return f"[sticker] {sticker.get('emoji', '')}"
+    
+    # Location
+    if "location" in message:
+        loc = message["location"]
+        return f"[location] {loc.get('latitude')}, {loc.get('longitude')}"
+    
+    # Contact
+    if "contact" in message:
+        contact = message["contact"]
+        return f"[contact] {contact.get('first_name', '')} {contact.get('phone_number', '')}"
+    
+    # Poll
+    if "poll" in message:
+        poll = message["poll"]
+        return f"[poll] {poll.get('question', '')}"
+    
+    return "[unsupported message type]"
+
+
+def get_chat_type(message: dict[str, Any]) -> str:
+    """Get the chat type from a message.
+
+    Args:
+        message: Telegram Message object
+
+    Returns:
+        Chat type: private, group, supergroup, or channel
+    """
+    chat = message.get("chat", {})
+    return chat.get("type", "private")
+
+
+def get_sender_info(message: dict[str, Any]) -> tuple[str, str | None, str | None]:
+    """Extract sender information from a message.
+
+    Args:
+        message: Telegram Message object
+
+    Returns:
+        Tuple of (user_id, username, display_name)
+    """
+    from_user = message.get("from", {})
+    user_id = str(from_user.get("id", ""))
+    username = from_user.get("username")
+    
+    # Build display name
+    first_name = from_user.get("first_name", "")
+    last_name = from_user.get("last_name", "")
+    display_name = f"{first_name} {last_name}".strip() or username or user_id
+    
+    return user_id, username, display_name

--- a/repos/tgo-platform/app/domain/entities.py
+++ b/repos/tgo-platform/app/domain/entities.py
@@ -70,6 +70,7 @@ class ChatCompletionRequest(BaseModel):
     system_message: str | None = None
     # Desired output format for the assistant response: e.g., "text", "markdown", "html"
     expected_output: str | None = None
+    msg_type: int | None = 1
     extra: dict | None = None
     timeout_seconds: int | None = 120
 

--- a/repos/tgo-platform/app/domain/services/adapters/__init__.py
+++ b/repos/tgo-platform/app/domain/services/adapters/__init__.py
@@ -6,3 +6,5 @@ from .wecom import WeComAdapter
 from .wecom_bot import WeComBotAdapter
 from .feishu_bot import FeishuBotAdapter
 from .dingtalk_bot import DingTalkBotAdapter
+from .telegram import TelegramAdapter
+

--- a/repos/tgo-platform/app/domain/services/adapters/telegram.py
+++ b/repos/tgo-platform/app/domain/services/adapters/telegram.py
@@ -1,0 +1,83 @@
+"""Telegram Bot outbound adapter.
+
+Sends messages to Telegram using the Bot API sendMessage endpoint.
+"""
+from __future__ import annotations
+
+from app.domain.entities import StreamEvent
+from app.domain.services.adapters.base import BasePlatformAdapter
+from app.core.config import settings
+
+from app.api.telegram_utils import telegram_send_text
+
+
+class TelegramAdapter(BasePlatformAdapter):
+    """Outbound adapter for Telegram Bot.
+
+    - Non-streaming: sends the final aggregated content via sendMessage API
+    - Uses chat_id from incoming message to reply (required)
+    - Requires bot_token for authentication
+
+    Docs:
+    - sendMessage: https://core.telegram.org/bots/api#sendmessage
+    """
+
+    supports_stream = False
+
+    def __init__(
+        self,
+        bot_token: str,
+        chat_id: str,
+        parse_mode: str | None = None,
+        http_timeout: int | None = None,
+    ) -> None:
+        """Initialize Telegram adapter.
+
+        Args:
+            bot_token: Bot token from @BotFather
+            chat_id: Target chat ID for replies
+            parse_mode: Optional message parsing mode (Markdown, HTML)
+            http_timeout: Request timeout in seconds
+        """
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+        self.parse_mode = parse_mode
+        self.http_timeout = http_timeout or settings.request_timeout_seconds
+
+    async def send_incremental(self, ev: StreamEvent) -> None:
+        # Telegram adapter does not support streaming output; ignore incremental events
+        return
+
+    async def send_final(self, content: dict) -> None:
+        """Send final message to Telegram chat.
+
+        Args:
+            content: Dict with 'text' key containing the message
+
+        Raises:
+            RuntimeError: If bot_token or chat_id is missing
+        """
+        text = (content or {}).get("text") or ""
+        print(f"[TELEGRAM ADAPTER] send_final called with text length: {len(text)}")
+        
+        if not text:
+            print("[TELEGRAM ADAPTER] Empty text, skipping send")
+            return
+
+        if not self.bot_token:
+            raise RuntimeError("Telegram adapter requires bot_token")
+
+        if not self.chat_id:
+            raise RuntimeError("Telegram adapter requires chat_id")
+
+        print(f"[TELEGRAM ADAPTER] Sending to chat_id={self.chat_id}: {text[:100]}...")
+        
+        # Send text message via Telegram Bot API
+        result = await telegram_send_text(
+            bot_token=self.bot_token,
+            chat_id=self.chat_id,
+            text=text[:4096],  # Telegram text limit
+            parse_mode=self.parse_mode,
+            timeout=self.http_timeout,
+        )
+        print(f"[TELEGRAM ADAPTER] Send result: {result}")

--- a/repos/tgo-platform/app/domain/services/listeners/__init__.py
+++ b/repos/tgo-platform/app/domain/services/listeners/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from .email_listener import EmailChannelListener, EmailPlatformConfig
+from .telegram_listener import TelegramChannelListener, TelegramPlatformConfig
 
 __all__ = [
     "EmailChannelListener",
     "EmailPlatformConfig",
+    "TelegramChannelListener",
+    "TelegramPlatformConfig",
 ]
+

--- a/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
+++ b/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
@@ -1,0 +1,465 @@
+"""Telegram Bot message consumer using getUpdates polling.
+
+This module implements a polling-based approach for Telegram messages:
+- Uses Telegram's getUpdates API (long polling) instead of webhook
+- Suitable for local development or servers without public HTTPS endpoints
+- Automatically deletes webhook when starting and uses polling mode
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.config import settings
+from app.db.models import Platform, TelegramInbox
+from app.domain.entities import NormalizedMessage
+from app.domain.ports import MessageNormalizer, TgoApiClient, SSEManager
+from app.domain.services.dispatcher import process_message
+from app.infra.visitor_client import VisitorService
+from app.api.telegram_utils import telegram_get_file, telegram_download_file
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+class TelegramPlatformConfig(BaseModel):
+    """Per-platform Telegram Bot configuration stored in Platform.config when type='telegram'."""
+
+    bot_token: str = ""                    # Bot token from @BotFather
+    webhook_secret: str | None = None      # Optional secret_token for webhook verification
+
+    # Polling configuration
+    polling_interval_seconds: int = 1      # How often to poll getUpdates
+    polling_timeout_seconds: int = 30      # Long polling timeout (Telegram recommends 30+)
+    processing_batch_size: int = 10
+    max_retry_attempts: int = 3
+
+
+@dataclass
+class _PlatformEntry:
+    id: uuid.UUID
+    project_id: uuid.UUID
+    api_key: str | None
+    cfg: TelegramPlatformConfig
+    last_update_id: int = 0  # Track last processed update_id for this platform
+
+
+class TelegramChannelListener:
+    """Telegram Bot consumer using getUpdates long polling.
+
+    This approach:
+    1. Calls Telegram's getUpdates API to fetch new messages
+    2. Processes each message via dispatcher
+    3. Stores to TelegramInbox for audit/retry purposes
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        normalizer: MessageNormalizer,
+        tgo_api_client: TgoApiClient,
+        sse_manager: SSEManager,
+    ) -> None:
+        self._session_factory = session_factory
+        self._normalizer = normalizer
+        self._tgo_api_client = tgo_api_client
+        self._sse_manager = sse_manager
+        self._stop_event = asyncio.Event()
+        self._consumer_task: asyncio.Task | None = None
+        self._visitor_service = VisitorService(
+            base_url=settings.api_base,
+            cache_ttl_seconds=300,
+            redis_url=settings.redis_url,
+        )
+        # Track last_update_id per platform to avoid duplicate processing
+        self._platform_offsets: dict[uuid.UUID, int] = {}
+
+    async def start(self) -> None:
+        if self._consumer_task is None or self._consumer_task.done():
+            self._consumer_task = asyncio.create_task(self._consumer_loop())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._consumer_task:
+            self._consumer_task.cancel()
+            try:
+                await self._consumer_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _load_active_telegram_platforms(self) -> list[_PlatformEntry]:
+        """Load all active Telegram platforms."""
+        async with self._session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(Platform.id, Platform.project_id, Platform.api_key, Platform.config)
+                    .where(Platform.is_active.is_(True), Platform.type == "telegram")
+                )
+            ).all()
+        platforms: list[_PlatformEntry] = []
+        for pid, project_id, api_key, cfg_dict in rows:
+            try:
+                cfg = TelegramPlatformConfig(**(cfg_dict or {}))
+                if not cfg.bot_token:
+                    print(f"[TELEGRAM] Skip platform {pid}: missing bot_token")
+                    continue
+                # Get last_update_id from memory or start at 0
+                last_id = self._platform_offsets.get(pid, 0)
+                platforms.append(_PlatformEntry(
+                    id=pid,
+                    project_id=project_id,
+                    api_key=api_key,
+                    cfg=cfg,
+                    last_update_id=last_id,
+                ))
+            except Exception as e:
+                print(f"[TELEGRAM] Skip platform {pid}: invalid config: {e}")
+        return platforms
+
+    async def _delete_webhook_if_exists(self, bot_token: str) -> None:
+        """Delete any existing webhook to enable getUpdates mode."""
+        try:
+            url = f"{TELEGRAM_API_BASE}/bot{bot_token}/deleteWebhook"
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(url)
+                result = resp.json()
+                if result.get("ok"):
+                    print(f"[TELEGRAM] Webhook deleted, switching to polling mode")
+        except Exception as e:
+            print(f"[TELEGRAM] Warning: Could not delete webhook: {e}")
+
+    async def _get_updates(
+        self,
+        bot_token: str,
+        offset: int,
+        timeout: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Call Telegram getUpdates API with long polling."""
+        url = f"{TELEGRAM_API_BASE}/bot{bot_token}/getUpdates"
+        params = {
+            "offset": offset,
+            "timeout": timeout,
+            "allowed_updates": ["message", "edited_message"],
+        }
+        
+        try:
+            async with httpx.AsyncClient(timeout=timeout + 10) as client:
+                resp = await client.get(url, params=params)
+                result = resp.json()
+                
+                if result.get("ok"):
+                    return result.get("result", [])
+                else:
+                    error_desc = result.get("description", "Unknown error")
+                    print(f"[TELEGRAM] getUpdates error: {error_desc}")
+                    return []
+        except httpx.TimeoutException:
+            # Normal for long polling when no messages
+            return []
+        except Exception as e:
+            print(f"[TELEGRAM] getUpdates request failed: {e}")
+            return []
+
+    def _extract_message_data(self, update: dict[str, Any]) -> dict[str, Any] | None:
+        """Extract message data from a Telegram Update object."""
+        message = update.get("message") or update.get("edited_message")
+        if not message:
+            return None
+        
+        from_user = message.get("from", {})
+        chat = message.get("chat", {})
+        
+        # Get message content (text, caption, or type indicator)
+        content = ""
+        msg_type = "text"
+        
+        if "text" in message:
+            content = message["text"]
+            msg_type = 1 # TEXT
+        elif "photo" in message:
+            # Picking the largest photo
+            photos = message.get("photo", [])
+            if photos:
+                largest = photos[-1]
+                content = message.get("caption") or "[Photo]"
+                msg_type = 2 # IMAGE
+                file_id = largest.get("file_id")
+            else:
+                content = "[Photo]"
+                msg_type = 1
+                file_id = None
+        elif "document" in message:
+            content = message.get("caption", "[Document]")
+            msg_type = 3 # FILE
+        elif "sticker" in message:
+            content = message.get("sticker", {}).get("emoji", "[Sticker]")
+            msg_type = 1
+        elif "voice" in message:
+            content = "[Voice message]"
+            msg_type = 4 # VOICE
+        elif "video" in message:
+            content = message.get("caption", "[Video]")
+            msg_type = 5 # VIDEO
+        else:
+            content = "[Unsupported message type]"
+            msg_type = 1
+        
+        return {
+            "update_id": update.get("update_id"),
+            "message_id": message.get("message_id"),
+            "from_user": str(from_user.get("id", "")),
+            "from_username": from_user.get("username"),
+            "from_display_name": " ".join(filter(None, [
+                from_user.get("first_name"),
+                from_user.get("last_name"),
+            ])) or from_user.get("username") or str(from_user.get("id", "")),
+            "chat_id": str(chat.get("id", "")),
+            "chat_type": chat.get("type", "private"),
+            "content": content,
+            "msg_type": msg_type,
+            "file_id": file_id if msg_type == 2 else None,
+            "raw_payload": update,
+            "date": message.get("date"),
+        }
+
+    async def _store_to_inbox(
+        self,
+        session: AsyncSession,
+        platform: _PlatformEntry,
+        msg_data: dict[str, Any],
+    ) -> TelegramInbox:
+        """Store message to TelegramInbox for audit purposes."""
+        record = TelegramInbox(
+            platform_id=platform.id,
+            update_id=msg_data["update_id"],
+            message_id=str(msg_data["message_id"]),
+            from_user=msg_data["from_user"],
+            from_username=msg_data.get("from_username"),
+            from_display_name=msg_data.get("from_display_name"),
+            chat_id=msg_data["chat_id"],
+            chat_type=msg_data["chat_type"],
+            msg_type=str(msg_data["msg_type"]),
+            content=msg_data["content"],
+            raw_payload=msg_data["raw_payload"],
+            status="processing",
+            fetched_at=datetime.now(timezone.utc),
+        )
+        session.add(record)
+        await session.flush()
+        return record
+
+    def _build_mapped_message(self, platform: _PlatformEntry, msg_data: dict[str, Any]) -> dict[str, Any]:
+        """Build the NormalizedMessage-like raw dict for downstream normalization."""
+        telegram_ctx: dict[str, Any] = {
+            "chat_id": msg_data["chat_id"],
+            "chat_type": msg_data["chat_type"],
+            "from_username": msg_data.get("from_username"),
+            "from_display_name": msg_data.get("from_display_name"),
+            "msg_type": msg_data["msg_type"],
+            "bot_token": platform.cfg.bot_token,
+        }
+
+        return {
+            "source": "telegram",
+            "from_uid": msg_data["from_user"],
+            "content": msg_data["content"] or "",
+            "platform_api_key": platform.api_key or "",
+            "platform_type": "telegram",
+            "platform_id": str(platform.id),
+            "extra": {
+                "project_id": str(platform.project_id),
+                "msg_type": msg_data["msg_type"],
+                "telegram": telegram_ctx,
+            },
+        }
+
+    async def _get_or_register_visitor(
+        self,
+        platform: _PlatformEntry,
+        msg_data: dict[str, Any],
+    ) -> tuple[Any | None, str | None, str | None]:
+        """Visitor retrieval/registration with cache-first approach."""
+        display_name: str | None = msg_data.get("from_display_name") or msg_data.get("from_username") or msg_data["from_user"]
+        avatar_url: str | None = None
+        visitor = None
+
+        # Check cache first
+        try:
+            cache_key = self._visitor_service.make_cache_key(str(platform.project_id), "telegram", msg_data["from_user"])
+            cached = await self._visitor_service.get_cached(cache_key)
+            if cached:
+                display_name = cached.nickname or cached.name or display_name
+                avatar_url = cached.avatar_url
+                return cached, display_name, avatar_url
+        except Exception as e:
+            print(f"[TELEGRAM] Visitor cache lookup failed for {platform.id}: {e}")
+
+        # Register or get visitor via tgo-api
+        if platform.api_key:
+            try:
+                visitor = await self._visitor_service.register_or_get(
+                    platform_api_key=platform.api_key,
+                    project_id=str(platform.project_id),
+                    platform_type="telegram",
+                    platform_open_id=msg_data["from_user"],
+                    nickname=display_name,
+                    avatar_url=avatar_url,
+                )
+            except Exception as e:
+                print(f"[TELEGRAM] Visitor registration failed for {platform.id}: {e}")
+
+        return visitor, display_name, avatar_url
+
+    async def _process_update(
+        self,
+        platform: _PlatformEntry,
+        update: dict[str, Any],
+    ) -> None:
+        """Process a single Telegram update."""
+        msg_data = self._extract_message_data(update)
+        if not msg_data:
+            return
+        
+        print(f"[TELEGRAM] Processing message from {msg_data['from_display_name']} in {msg_data['chat_type']}: {msg_data['content'][:50]}...")
+
+        async with self._session_factory() as db:
+            try:
+                # 1) Get/register visitor FIRST to get the official UUID from tgo-api
+                visitor, display_name, avatar_url = await self._get_or_register_visitor(platform, msg_data)
+                
+                # 2) If it's an image, download from Telegram and upload to tgo-api
+                if msg_data["msg_type"] == 2 and msg_data.get("file_id") and visitor:
+                    try:
+                        # a) Get file path from Telegram
+                        file_info = await telegram_get_file(platform.cfg.bot_token, msg_data["file_id"])
+                        if file_info.get("ok"):
+                            file_path = file_info["result"].get("file_path")
+                            if file_path:
+                                # b) Download file bytes
+                                file_bytes = await telegram_download_file(platform.cfg.bot_token, file_path)
+                                
+                                # c) Upload to tgo-api using the real visitor.channel_id
+                                upload_url = f"{settings.api_base.rstrip('/')}/v1/chat/upload"
+                                channel_id = visitor.channel_id or f"{visitor.id}-vtr"
+                                
+                                print(f"[TELEGRAM] Uploading image for visitor {visitor.id}, channel {channel_id}...")
+                                async with httpx.AsyncClient(timeout=60) as client:
+                                    files = {"file": ("image.jpg", file_bytes, "image/jpeg")}
+                                    data = {
+                                        "channel_id": channel_id,
+                                        "channel_type": 251,  # CHANNEL_TYPE_CUSTOMER_SERVICE
+                                        "platform_api_key": platform.api_key or "",
+                                    }
+                                    resp = await client.post(upload_url, data=data, files=files)
+                                    if resp.status_code == 200:
+                                        upload_result = resp.json()
+                                        # Use "file_url" from ChatFileUploadResponse
+                                        new_url = upload_result.get("file_url") or upload_result.get("url")
+                                        if new_url:
+                                            msg_data["content"] = new_url
+                                            print(f"[TELEGRAM] Image uploaded successfully: {msg_data['content']}")
+                                        else:
+                                            print(f"[TELEGRAM] Image upload response missing URL: {upload_result}")
+                                    else:
+                                        print(f"[TELEGRAM] Failed to upload image to tgo-api (status {resp.status_code}): {resp.text}")
+                    except Exception as e:
+                        print(f"[TELEGRAM] Error handling image from Telegram: {e}")
+                # Store to inbox for audit
+                record = await self._store_to_inbox(db, platform, msg_data)
+                
+                # Build mapped message
+                mapped_raw = self._build_mapped_message(platform, msg_data)
+                
+                # 3) Normalize and process
+                if display_name or avatar_url:
+                    extra = mapped_raw.get("extra") or {}
+                    extra["visitor_profile"] = {"nickname": display_name, "avatar_url": avatar_url}
+                    mapped_raw["extra"] = extra
+                
+                # Normalize and process
+                msg: NormalizedMessage = await self._normalizer.normalize(mapped_raw)
+                reply_text = await process_message(
+                    msg=msg,
+                    db=db,
+                    tgo_api_client=self._tgo_api_client,
+                    sse_manager=self._sse_manager,
+                )
+                
+                # Mark as completed
+                record.ai_reply = reply_text
+                record.status = "completed"
+                record.processed_at = datetime.now(timezone.utc)
+                await db.commit()
+                
+                print(f"[TELEGRAM] Reply sent to {msg_data['chat_id']}")
+                
+            except Exception as e:
+                print(f"[TELEGRAM] Processing failed: {e}")
+                await db.rollback()
+
+    async def _poll_platform(self, platform: _PlatformEntry) -> int:
+        """Poll a single platform for new messages. Returns new offset."""
+        offset = platform.last_update_id + 1 if platform.last_update_id else 0
+        timeout = platform.cfg.polling_timeout_seconds
+        
+        updates = await self._get_updates(platform.cfg.bot_token, offset, timeout)
+        
+        new_offset = platform.last_update_id
+        for update in updates:
+            update_id = update.get("update_id", 0)
+            if update_id > new_offset:
+                new_offset = update_id
+            
+            try:
+                await self._process_update(platform, update)
+            except Exception as e:
+                print(f"[TELEGRAM] Error processing update {update_id}: {e}")
+        
+        return new_offset
+
+    async def _consumer_loop(self) -> None:
+        """Main consumer loop - polls all active Telegram platforms."""
+        print("[TELEGRAM] Consumer loop started (polling mode)")
+        
+        # Initial load and delete webhooks
+        platforms = await self._load_active_telegram_platforms()
+        for p in platforms:
+            await self._delete_webhook_if_exists(p.cfg.bot_token)
+        
+        while not self._stop_event.is_set():
+            try:
+                platforms = await self._load_active_telegram_platforms()
+                
+                if not platforms:
+                    await asyncio.sleep(5)
+                    continue
+                
+                # Poll each platform concurrently
+                tasks = []
+                for p in platforms:
+                    tasks.append(self._poll_platform(p))
+                
+                if tasks:
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+                    
+                    # Update offsets
+                    for i, p in enumerate(platforms):
+                        if isinstance(results[i], int):
+                            self._platform_offsets[p.id] = results[i]
+                
+                # Short sleep between polling cycles
+                interval = platforms[0].cfg.polling_interval_seconds if platforms else 1
+                await asyncio.sleep(max(0.5, interval))
+                
+            except Exception as e:
+                print(f"[TELEGRAM] Consumer loop error: {e}")
+                await asyncio.sleep(5)
+        
+        print("[TELEGRAM] Consumer loop stopped")

--- a/repos/tgo-platform/migrations/versions/add_telegram_inbox.py
+++ b/repos/tgo-platform/migrations/versions/add_telegram_inbox.py
@@ -1,0 +1,59 @@
+"""Add pt_telegram_inbox table for Telegram Bot messages
+
+Revision ID: add_telegram_inbox
+Revises: add_dingtalk_inbox
+Create Date: 2026-01-06
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'add_telegram_inbox'
+down_revision = 'add_dingtalk_inbox'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'pt_telegram_inbox',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('platform_id', sa.UUID(), nullable=False),
+        sa.Column('message_id', sa.String(length=255), nullable=False),
+        sa.Column('update_id', sa.BigInteger(), nullable=True),
+        sa.Column('from_user', sa.String(length=255), nullable=False),
+        sa.Column('from_username', sa.String(length=255), nullable=True),
+        sa.Column('from_display_name', sa.String(length=255), nullable=True),
+        sa.Column('chat_id', sa.String(length=255), nullable=False),
+        sa.Column('chat_type', sa.String(length=20), server_default='private', nullable=False),
+        sa.Column('msg_type', sa.String(length=50), server_default='text', nullable=False),
+        sa.Column('content', sa.Text(), nullable=True),
+        sa.Column('ai_reply', sa.Text(), nullable=True),
+        sa.Column('raw_payload', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('received_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('fetched_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('processed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('status', sa.String(length=20), server_default='pending', nullable=False),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('retry_count', sa.Integer(), server_default='0', nullable=False),
+        sa.ForeignKeyConstraint(['platform_id'], ['pt_platforms.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('platform_id', 'message_id', 'chat_id', name='uq_telegram_inbox_platform_message_chat')
+    )
+    op.create_index('ix_pt_telegram_inbox_platform_id', 'pt_telegram_inbox', ['platform_id'], unique=False)
+    op.create_index('ix_pt_telegram_inbox_chat_id', 'pt_telegram_inbox', ['chat_id'], unique=False)
+    op.create_index('ix_telegram_inbox_platform_status', 'pt_telegram_inbox', ['platform_id', 'status'], unique=False)
+    op.create_index('ix_telegram_inbox_status_fetched', 'pt_telegram_inbox', ['status', 'fetched_at'], unique=False)
+    op.create_index('ix_telegram_inbox_update_id', 'pt_telegram_inbox', ['update_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_telegram_inbox_update_id', table_name='pt_telegram_inbox')
+    op.drop_index('ix_telegram_inbox_status_fetched', table_name='pt_telegram_inbox')
+    op.drop_index('ix_telegram_inbox_platform_status', table_name='pt_telegram_inbox')
+    op.drop_index('ix_pt_telegram_inbox_chat_id', table_name='pt_telegram_inbox')
+    op.drop_index('ix_pt_telegram_inbox_platform_id', table_name='pt_telegram_inbox')
+    op.drop_table('pt_telegram_inbox')

--- a/repos/tgo-web/src/components/platforms/TelegramPlatformConfig.tsx
+++ b/repos/tgo-web/src/components/platforms/TelegramPlatformConfig.tsx
@@ -1,0 +1,347 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import PlatformAISettings from '@/components/platforms/PlatformAISettings';
+import type { Platform, PlatformConfig, PlatformAIMode } from '@/types';
+import { usePlatformStore } from '@/stores/platformStore';
+import { useToast } from '@/hooks/useToast';
+import { showApiError, showSuccess } from '@/utils/toastHelpers';
+import { toAbsoluteUrl } from '@/utils/config';
+
+interface Props {
+    platform: Platform; // expected: platform.type === 'telegram'
+}
+
+const TelegramPlatformConfig: React.FC<Props> = ({ platform }) => {
+    const { t } = useTranslation();
+    const { showToast } = useToast();
+    const updatePlatformConfig = usePlatformStore(s => s.updatePlatformConfig);
+    const resetPlatformConfig = usePlatformStore(s => s.resetPlatformConfig);
+    const updatePlatform = usePlatformStore(s => s.updatePlatform);
+    const deletePlatform = usePlatformStore(s => s.deletePlatform);
+    const enablePlatform = usePlatformStore(s => s.enablePlatform);
+    const disablePlatform = usePlatformStore(s => s.disablePlatform);
+    const platforms = usePlatformStore(s => s.platforms);
+    const hasConfigChanges = usePlatformStore(s => s.hasConfigChanges(platform.id));
+    const isUpdating = usePlatformStore(s => s.isUpdating);
+    const navigate = useNavigate();
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [isToggling, setIsToggling] = useState(false);
+    const isEnabled = platform.status === 'connected';
+
+    // Name editing
+    const [platformName, setPlatformName] = useState<string>(platform.name);
+    useEffect(() => { setPlatformName(platform.name); }, [platform.name]);
+    const hasNameChanged = useMemo(() => platformName.trim() !== platform.name, [platformName, platform.name]);
+
+    // AI Settings state
+    const [aiAgentIds, setAiAgentIds] = useState<string[]>(platform.agent_ids ?? []);
+    const [aiMode, setAiMode] = useState<PlatformAIMode>(platform.ai_mode ?? 'auto');
+    const [fallbackTimeout, setFallbackTimeout] = useState<number | null>(platform.fallback_to_ai_timeout ?? null);
+
+    useEffect(() => {
+        setAiAgentIds(platform.agent_ids ?? []);
+        setAiMode(platform.ai_mode ?? 'auto');
+        setFallbackTimeout(platform.fallback_to_ai_timeout ?? null);
+    }, [platform.agent_ids, platform.ai_mode, platform.fallback_to_ai_timeout]);
+
+    const hasAISettingsChanged = useMemo(() => {
+        const origAgentIds = platform.agent_ids ?? [];
+        const origMode = platform.ai_mode ?? 'auto';
+        const origTimeout = platform.fallback_to_ai_timeout ?? null;
+        const agentIdsChanged = JSON.stringify(aiAgentIds.sort()) !== JSON.stringify([...origAgentIds].sort());
+        const modeChanged = aiMode !== origMode;
+        const timeoutChanged = fallbackTimeout !== origTimeout;
+        return agentIdsChanged || modeChanged || timeoutChanged;
+    }, [aiAgentIds, aiMode, fallbackTimeout, platform.agent_ids, platform.ai_mode, platform.fallback_to_ai_timeout]);
+
+    const canSave = hasConfigChanges || hasNameChanged || hasAISettingsChanged;
+
+    // Local form state sourced from platform.config
+    const [formValues, setFormValues] = useState(() => ({
+        botToken: (platform.config as any)?.bot_token ?? '',
+        webhookSecret: (platform.config as any)?.webhook_secret ?? '',
+        // Convert relative callback URL to absolute
+        callbackUrl: toAbsoluteUrl((platform as any)?.callback_url ?? ''),
+    }));
+
+    useEffect(() => {
+        setFormValues({
+            botToken: (platform.config as any)?.bot_token ?? '',
+            webhookSecret: (platform.config as any)?.webhook_secret ?? '',
+            callbackUrl: toAbsoluteUrl((platform as any)?.callback_url ?? ''),
+        });
+    }, [platform]);
+
+    const handleChange = (patch: Partial<typeof formValues>) => {
+        setFormValues(v => ({ ...v, ...patch }));
+        const { callbackUrl, ...rest } = { ...formValues, ...patch };
+        // Write changes to store; callbackUrl is derived from backend (callback_url)
+        const toSave: Partial<PlatformConfig> = {
+            ...(rest.botToken !== undefined ? { botToken: rest.botToken } : {}),
+            ...(rest.webhookSecret !== undefined ? { webhookSecret: rest.webhookSecret } : {}),
+        };
+        updatePlatformConfig(platform.id, toSave);
+    };
+
+    const handleSave = async () => {
+        try {
+            const updates: Partial<Platform> = {};
+
+            if (hasConfigChanges) {
+                // Transform camelCase form values to snake_case API payload for Telegram
+                updates.config = {
+                    bot_token: (formValues.botToken || '').trim(),
+                    webhook_secret: (formValues.webhookSecret || '').trim(),
+                } as any;
+            }
+            if (hasNameChanged) {
+                updates.name = platformName.trim();
+            }
+            if (hasAISettingsChanged) {
+                updates.agent_ids = aiAgentIds.length > 0 ? aiAgentIds : null;
+                updates.ai_mode = aiMode;
+                updates.fallback_to_ai_timeout = aiMode === 'assist' ? fallbackTimeout : null;
+            }
+
+            if (Object.keys(updates).length > 0) {
+                await updatePlatform(platform.id, updates);
+                if (hasConfigChanges) {
+                    resetPlatformConfig(platform.id);
+                }
+            }
+            showSuccess(showToast, t('platforms.telegram.messages.saveSuccess', '保存成功'), t('platforms.telegram.messages.saveSuccessMessage', 'Telegram 配置已更新'));
+        } catch (e) {
+            showApiError(showToast, e);
+        }
+    };
+
+    const displayName = platform.display_name || platform.name;
+
+    return (
+        <main className="flex flex-col flex-1 min-h-0 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
+            <header className="px-6 py-4 border-b border-gray-200/80 dark:border-gray-700/80 flex justify-between items-center bg-white/60 dark:bg-gray-800/60 backdrop-blur-lg sticky top-0 z-10">
+                <div>
+                    <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">{t('platforms.telegram.header.title', { name: displayName, defaultValue: '{{name}} 配置' })}</h2>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{t('platforms.telegram.header.subtitle', '配置 Telegram Bot 所需的凭据与回调。')}</p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <button
+                        disabled={isUpdating || isDeleting}
+                        onClick={() => setConfirmOpen(true)}
+                        className={`px-3 py-1.5 text-sm rounded-md ${isDeleting ? 'bg-red-400 text-white' : 'bg-red-600 dark:bg-red-500 text-white hover:bg-red-700 dark:hover:bg-red-600'}`}
+                    >
+                        {isDeleting ? t('platforms.telegram.buttons.deleting', '删除中…') : t('platforms.telegram.buttons.delete', '删除')}
+                    </button>
+                    <button
+                        disabled={isUpdating || isDeleting || isToggling}
+                        onClick={async () => {
+                            if (isToggling) return;
+                            setIsToggling(true);
+                            try {
+                                if (isEnabled) {
+                                    await disablePlatform(platform.id);
+                                    showSuccess(showToast, t('platforms.telegram.messages.disabled', '平台已禁用'));
+                                } else {
+                                    await enablePlatform(platform.id);
+                                    showSuccess(showToast, t('platforms.telegram.messages.enabled', '平台已启用'));
+                                }
+                            } catch (e) {
+                                showApiError(showToast, e);
+                            } finally {
+                                setIsToggling(false);
+                            }
+                        }}
+                        className={`px-3 py-1.5 text-sm rounded-md text-white ${isEnabled ? 'bg-gray-600 dark:bg-gray-500 hover:bg-gray-700 dark:hover:bg-gray-600' : 'bg-green-600 dark:bg-green-500 hover:bg-green-700 dark:hover:bg-green-600'} ${isToggling ? 'opacity-70 cursor-not-allowed' : ''}`}
+                    >
+                        {isToggling ? (isEnabled ? t('platforms.telegram.buttons.disabling', '禁用中…') : t('platforms.telegram.buttons.enabling', '启用中…')) : (isEnabled ? t('platforms.telegram.buttons.disable', '禁用') : t('platforms.telegram.buttons.enable', '启用'))}
+                    </button>
+
+                    <button
+                        disabled={!canSave || isUpdating}
+                        onClick={handleSave}
+                        className={`px-3 py-1.5 text-sm rounded-md ${canSave ? 'bg-blue-600 dark:bg-blue-500 text-white hover:bg-blue-700 dark:hover:bg-blue-600' : 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed'}`}
+                    >
+                        {isUpdating ? t('platforms.telegram.buttons.saving', '保存中…') : t('platforms.telegram.buttons.save', '保存')}
+                    </button>
+                </div>
+            </header>
+
+            <div className="flex flex-1 min-h-0 flex-col lg:flex-row gap-4 p-6">
+                {/* Left: form */}
+                <section className="lg:w-2/5 w-full bg-white/80 dark:bg-gray-800/80 backdrop-blur-md p-5 rounded-lg shadow-sm border border-gray-200/60 dark:border-gray-700/60 space-y-4 overflow-y-auto min-h-0 auto-hide-scrollbar">
+                    {/* 平台名称 */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">{t('platforms.telegram.form.name', '平台名称')}</label>
+                        <input
+                            type="text"
+                            value={platformName}
+                            onChange={(e) => setPlatformName(e.target.value)}
+                            placeholder={t('platforms.telegram.form.namePlaceholder', '请输入平台名称')}
+                            className="w-full text-sm p-1.5 border border-gray-300/80 dark:border-gray-600/80 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 bg-white/90 dark:bg-gray-700/50 dark:text-gray-200"
+                        />
+                    </div>
+
+                    {/* 回调URL（只读，需设置到 Telegram） */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">{t('platforms.telegram.form.callbackUrl', 'Webhook URL')}</label>
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="text"
+                                value={formValues.callbackUrl}
+                                readOnly
+                                placeholder={t('platforms.telegram.form.callbackUrlPlaceholder', '平台创建后会生成 Webhook URL')}
+                                className="flex-1 text-sm p-1.5 border border-gray-300/80 dark:border-gray-600/80 rounded-md bg-gray-100/70 dark:bg-gray-700/50 dark:text-gray-200 focus:outline-none font-mono"
+                            />
+                            <button
+                                type="button"
+                                disabled={!formValues.callbackUrl}
+                                onClick={async () => {
+                                    try {
+                                        if (!formValues.callbackUrl) return;
+                                        await navigator.clipboard.writeText(formValues.callbackUrl);
+                                        showSuccess(showToast, t('platforms.telegram.messages.urlCopied', 'Webhook URL 已复制'));
+                                    } catch (e) {
+                                        showApiError(showToast, e);
+                                    }
+                                }}
+                                className={`px-2 py-1 text-xs rounded-md ${formValues.callbackUrl ? 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200' : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed'}`}
+                            >
+                                {t('platforms.telegram.buttons.copy', '复制')}
+                            </button>
+                        </div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('platforms.telegram.form.callbackUrlHint', '使用 setWebhook API 将此 URL 设置为 Bot 的 Webhook 地址。')}</p>
+                    </div>
+
+                    {/* Bot Token */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">{t('platforms.telegram.form.botToken', 'Bot Token')}</label>
+                        <input
+                            type="password"
+                            value={formValues.botToken}
+                            onChange={(e) => handleChange({ botToken: e.target.value })}
+                            placeholder={t('platforms.telegram.form.botTokenPlaceholder', '例如: 123456789:ABCdefGHIjklMNOpqrsTUVwxyz')}
+                            className="w-full text-sm p-1.5 border border-gray-300/80 dark:border-gray-600/80 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 bg-white/90 dark:bg-gray-700/50 dark:text-gray-200"
+                        />
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('platforms.telegram.form.botTokenHint', '通过 @BotFather 创建 Bot 后获取的 Token，请妥善保管。')}</p>
+                    </div>
+
+                    {/* Webhook Secret (可选) */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">{t('platforms.telegram.form.webhookSecret', 'Webhook Secret（可选）')}</label>
+                        <input
+                            type="text"
+                            value={formValues.webhookSecret}
+                            onChange={(e) => handleChange({ webhookSecret: e.target.value })}
+                            placeholder={t('platforms.telegram.form.webhookSecretPlaceholder', '用于验证 webhook 请求来源')}
+                            className="w-full text-sm p-1.5 border border-gray-300/80 dark:border-gray-600/80 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 bg-white/90 dark:bg-gray-700/50 dark:text-gray-200"
+                        />
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{t('platforms.telegram.form.webhookSecretHint', '在 setWebhook 时通过 secret_token 参数设置相同的值，用于验证请求来源。')}</p>
+                    </div>
+
+                    {/* AI Settings */}
+                    <PlatformAISettings
+                        platform={platform}
+                        agentIds={aiAgentIds}
+                        aiMode={aiMode}
+                        fallbackTimeout={fallbackTimeout}
+                        onAgentIdsChange={setAiAgentIds}
+                        onAIModeChange={setAiMode}
+                        onFallbackTimeoutChange={setFallbackTimeout}
+                    />
+                </section>
+
+                {/* Right: comprehensive guide */}
+                <section className="lg:w-3/5 w-full bg-white/80 dark:bg-gray-800/80 backdrop-blur-md p-5 rounded-lg shadow-sm border border-gray-200/60 dark:border-gray-700/60 min-h-0 overflow-y-auto auto-hide-scrollbar space-y-4">
+                    <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{t('platforms.telegram.guide.title', 'Telegram Bot 配置指南')}</h3>
+
+                    <div className="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 text-green-800 dark:text-green-200 text-sm rounded-md p-3">
+                        <p className="font-medium">{t('platforms.telegram.guide.overview', '✨ 极简配置')}</p>
+                        <p className="mt-1">{t('platforms.telegram.guide.overviewText', '只需：①创建 Bot 获取 Token → ②填入 Token → ③点击「启用」。系统会自动配置 Webhook！')}</p>
+                    </div>
+
+                    <details className="rounded-md border border-gray-200 dark:border-gray-600 p-3 bg-white/70 dark:bg-gray-700/50" open>
+                        <summary className="cursor-pointer font-semibold text-gray-800 dark:text-gray-100">{t('platforms.telegram.guide.step1Title', '1️⃣ 创建 Telegram Bot')}</summary>
+                        <div className="text-sm text-gray-700 dark:text-gray-300 mt-2 space-y-2">
+                            <ol className="list-decimal pl-5 space-y-1">
+                                <li dangerouslySetInnerHTML={{ __html: t('platforms.telegram.guide.step1Item1', '在 Telegram 中搜索 <a class="text-blue-600 hover:underline" href="https://t.me/BotFather" target="_blank" rel="noreferrer">@BotFather</a> 并打开对话。') }} />
+                                <li>{t('platforms.telegram.guide.step1Item2', '发送 /newbot 命令开始创建机器人。')}</li>
+                                <li>{t('platforms.telegram.guide.step1Item3', '按提示输入机器人名称（显示名）和用户名（以 _bot 结尾）。')}</li>
+                                <li>{t('platforms.telegram.guide.step1Item4', 'BotFather 将返回 Bot Token，复制备用。')}</li>
+                            </ol>
+                        </div>
+                    </details>
+
+                    <details className="rounded-md border border-gray-200 dark:border-gray-600 p-3 bg-white/70 dark:bg-gray-700/50" open>
+                        <summary className="cursor-pointer font-semibold text-gray-800 dark:text-gray-100">{t('platforms.telegram.guide.step2Title', '2️⃣ 配置并启用')}</summary>
+                        <div className="text-sm text-gray-700 dark:text-gray-300 mt-2 space-y-2">
+                            <ol className="list-decimal pl-5 space-y-1">
+                                <li>{t('platforms.telegram.guide.step2Item1', '在左侧「Bot Token」输入框中粘贴 Token。')}</li>
+                                <li>{t('platforms.telegram.guide.step2Item2', '（可选）填写「Webhook Secret」增强安全性。')}</li>
+                                <li>{t('platforms.telegram.guide.step2Item3', '点击「保存」后，再点击右上角的「启用」按钮。')}</li>
+                            </ol>
+                            <div className="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded p-2 text-xs text-blue-800 dark:text-blue-200 mt-2">
+                                <p className="font-semibold">💡 自动配置</p>
+                                <p>{t('platforms.telegram.guide.step2AutoConfig', '点击「启用」后，系统会自动向 Telegram 注册 Webhook 地址，无需手动操作。')}</p>
+                            </div>
+                        </div>
+                    </details>
+
+                    <details className="rounded-md border border-gray-200 dark:border-gray-600 p-3 bg-white/70 dark:bg-gray-700/50">
+                        <summary className="cursor-pointer font-semibold text-gray-800 dark:text-gray-100">{t('platforms.telegram.guide.step3Title', '3️⃣ 测试机器人')}</summary>
+                        <div className="text-sm text-gray-700 dark:text-gray-300 mt-2 space-y-2">
+                            <ol className="list-decimal pl-5 space-y-1">
+                                <li>{t('platforms.telegram.guide.step3Item1', '在 Telegram 中搜索你的 Bot 用户名并开始对话。')}</li>
+                                <li>{t('platforms.telegram.guide.step3Item2', '发送任意消息，AI 将自动回复。')}</li>
+                                <li>{t('platforms.telegram.guide.step3Item3', '如需将 Bot 添加到群组，确保在 BotFather 中开启「Allow Groups」选项。')}</li>
+                            </ol>
+                            <a className="text-blue-600 dark:text-blue-400 hover:underline" href="https://core.telegram.org/bots/api" target="_blank" rel="noreferrer">{t('platforms.telegram.guide.docsLink', 'Telegram Bot API 文档')}</a>
+                        </div>
+                    </details>
+
+                </section>
+            </div>
+
+            {/* Scoped scrollbar style */}
+            <style>{`
+        .auto-hide-scrollbar { scrollbar-width: thin; scrollbar-color: rgba(0,0,0,0.3) transparent; }
+        .auto-hide-scrollbar::-webkit-scrollbar { width: 8px; height: 8px; }
+        .auto-hide-scrollbar::-webkit-scrollbar-thumb { background-color: transparent; border-radius: 4px; }
+        .auto-hide-scrollbar:hover::-webkit-scrollbar-thumb { background-color: rgba(0,0,0,0.35); }
+      `}</style>
+            <ConfirmDialog
+                isOpen={confirmOpen}
+                title={t('platforms.telegram.dialog.deleteTitle', '确认删除')}
+                message={t('platforms.telegram.dialog.deleteMessage', '确定要删除此 Telegram Bot 平台吗？此操作不可撤销。')}
+                confirmText={t('platforms.telegram.dialog.confirmDelete', '删除')}
+                cancelText={t('platforms.telegram.dialog.cancel', '取消')}
+                confirmVariant="danger"
+                isLoading={isDeleting}
+                onCancel={() => setConfirmOpen(false)}
+                onConfirm={async () => {
+                    if (isDeleting) return;
+                    setIsDeleting(true);
+                    try {
+                        const idx = platforms.findIndex(p => p.id === platform.id);
+                        const nextId = idx !== -1
+                            ? (idx < platforms.length - 1 ? platforms[idx + 1]?.id : (idx > 0 ? platforms[idx - 1]?.id : null))
+                            : null;
+                        await deletePlatform(platform.id);
+                        showSuccess(showToast, t('platforms.telegram.messages.deleteSuccess', '删除成功'), t('platforms.telegram.messages.deleteSuccessMessage', 'Telegram Bot 平台已删除'));
+                        setConfirmOpen(false);
+                        if (nextId) navigate(`/platforms/${nextId}`);
+                        else navigate('/platforms');
+                    } catch (e) {
+                        showApiError(showToast, e);
+                    } finally {
+                        setIsDeleting(false);
+                    }
+                }}
+            />
+        </main>
+    );
+};
+
+export default TelegramPlatformConfig;

--- a/repos/tgo-web/src/pages/PlatformConfigPage.tsx
+++ b/repos/tgo-web/src/pages/PlatformConfigPage.tsx
@@ -11,6 +11,7 @@ import DingTalkBotPlatformConfig from '@/components/platforms/DingTalkBotPlatfor
 import EmailPlatformConfig from '@/components/platforms/EmailPlatformConfig';
 import DouyinPlatformConfig from '@/components/platforms/DouyinPlatformConfig';
 import CustomPlatformConfig from '@/components/platforms/CustomPlatformConfig';
+import TelegramPlatformConfig from '@/components/platforms/TelegramPlatformConfig';
 
 /**
  * Platform Configuration page component
@@ -126,6 +127,10 @@ const PlatformConfigPage: React.FC = () => {
   // 自定义平台（Custom）
   if (platform.type === 'custom') {
     return <CustomPlatformConfig platform={platform} />;
+  }
+  // Telegram
+  if ((platform.type as any) === 'telegram') {
+    return <TelegramPlatformConfig platform={platform} />;
   }
 
   // Fallback to generic/placeholder config for other types


### PR DESCRIPTION
## Description / 功能描述

Add support for displaying image messages from Telegram users in the customer service backend.

为客服后台添加 Telegram 渠道图片消息显示支持。

## Changes / 变更内容

### tgo-api
- Add `msg_type` field to [ChatCompletionRequest](cci:2://file:///Volumes/t1/tgo/repos/tgo-api/app/schemas/chat.py:41:0-105:5) schema for message type detection (1=text, 2=image, 3=file)
- Implement automatic URL resolution for relative image paths (e.g., `/v1/chat/files/xxx` → full URL)
- Update [send_user_message_to_wukongim](cci:1://file:///Volumes/t1/tgo/repos/tgo-api/app/services/chat_service.py:448:0-488:14) to include [url](cci:1://file:///Volumes/t1/tgo/repos/tgo-api/app/core/config.py:499:4-511:46) field in payload for image/file messages
- Enable Telegram platform type in `platform_type_seed.py`

### tgo-platform
- Add `TelegramAdapter` for sending replies back to Telegram
- Add [TelegramChannelListener](cci:2://file:///Volumes/t1/tgo/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py:53:0-464:49) with `getUpdates` long polling support
- Implement image download from Telegram API and upload to tgo-api
- Add `telegram_utils.py` with helper functions (`telegram_get_file`, `telegram_download_file`, `telegram_send_photo`)
- Add `TelegramInbox` model and database migration
- Update [dispatcher.py](cci:7://file:///Volumes/t1/tgo/repos/tgo-platform/app/domain/services/dispatcher.py:0:0-0:0) to support Telegram adapter selection and `msg_type` propagation

### tgo-web
- Add `TelegramPlatformConfig.tsx` component for Telegram platform configuration

## Testing / 测试方式

1. Configure a Telegram bot in the platform settings / 在平台设置中配置 Telegram 机器人
2. Send an image from Telegram to the bot / 从 Telegram 向机器人发送一张图片
3. Verify the image displays correctly in the customer service chat interface / 验证图片在客服聊天界面中正常显示
