### PR TITLE
fix:  237d44a (update envs) 将telegram listener 中的 settings.api_base 统一改为 api_base_url

### DIFF
--- a/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
+++ b/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
@@ -74,7 +74,7 @@ class TelegramChannelListener:
         self._stop_event = asyncio.Event()
         self._consumer_task: asyncio.Task | None = None
         self._visitor_service = VisitorService(
-            base_url=settings.api_base,
+            base_url=settings.api_base_url,
             cache_ttl_seconds=300,
             redis_url=settings.redis_url,
         )


### PR DESCRIPTION
## Root Cause / 根本原因


上游提交 `237d44a` 将配置属性名从 `api_base` 统一改为 `api_base_url` 在同步该变更前添加，导致启动时抛出 `AttributeError`。

## Changes / 变更内容

| File | Change |
|------|--------|
| [app/domain/services/listeners/telegram_listener.py](https://github.com/tgoai/tgo/blob/db0c8280b98773fc90aff1ba9c69b32845b77f10/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py#L77C1-L78C1) | `settings.api_base` → `settings.api_base_url` (line 77) |

## Error Before Fix / 修复前错误

```python
AttributeError: 'Settings' object has no attribute 'api_base'