### PR TITLE
fix: update settings.api_base to settings.api_base_url in Telegram files

### DIFF
--- a/repos/tgo-platform/app/api/v1/messages.py
+++ b/repos/tgo-platform/app/api/v1/messages.py
@@ -45,7 +45,7 @@ def _internalize_url(url: str) -> str:
         return url
     
     # If URL is from localhost/api or localhost:8000, map it to internal settings.api_base
-    internal_base = settings.api_base.rstrip('/')
+    internal_base = settings.api_base_url.rstrip('/')
     
     import re
     # Case 1: http://localhost:8000/v1/...

--- a/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
+++ b/repos/tgo-platform/app/domain/services/listeners/telegram_listener.py
@@ -74,7 +74,7 @@ class TelegramChannelListener:
         self._stop_event = asyncio.Event()
         self._consumer_task: asyncio.Task | None = None
         self._visitor_service = VisitorService(
-            base_url=settings.api_base,
+            base_url=settings.api_base_url,
             cache_ttl_seconds=300,
             redis_url=settings.redis_url,
         )
@@ -346,7 +346,7 @@ class TelegramChannelListener:
                                 file_bytes = await telegram_download_file(platform.cfg.bot_token, file_path)
                                 
                                 # c) Upload to tgo-api using the real visitor.channel_id
-                                upload_url = f"{settings.api_base.rstrip('/')}/v1/chat/upload"
+                                upload_url = f"{settings.api_base_url.rstrip('/')}/v1/chat/upload"
                                 channel_id = visitor.channel_id or f"{visitor.id}-vtr"
                                 
                                 print(f"[TELEGRAM] Uploading image for visitor {visitor.id}, channel {channel_id}...")


### PR DESCRIPTION
After upstream commit 237d44a (update envs), settings attribute was renamed. Updated in:
- telegram_listener.py:77
- telegram_listener.py:349
- messages.py:48