### PR TITLE
fix: 代码执行 built_team.team.run 报错

### DIFF
--- a/repos/tgo-ai/app/runtime/supervisor/teams/runner.py
+++ b/repos/tgo-ai/app/runtime/supervisor/teams/runner.py
@@ -78,7 +78,7 @@ class AgnoTeamRunner:
 
     async def run(self, built_team: BuiltTeam, context: CoordinationContext) -> SupervisorRunResponse:
         start_time = time.time()
-        output = await built_team.team.run(context.message)
+        output = await built_team.team.arun(context.message)
         total_time = time.time() - start_time
 
         agent_results = self._convert_member_responses(output.member_responses, context)


### PR DESCRIPTION
代码执行报错
File "/app/app/runtime/supervisor/teams/runner.py", line 81, in run
    output = await built_team.team.run(context.message)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object TeamRunOutput can't be used in 'await' expression

应该修改built_team.team.arun(context.message)